### PR TITLE
ReactGA + Emoji Scaling + Zoom Control

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 npm i
-npm run build
+REACT_APP_WIR_ENV=production npm run build
 
 scp -r build wir-dev@dev.wir.by:/home/wir-dev/babajka-legends-map/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13091,6 +13091,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.0.tgz",
       "integrity": "sha512-akMy/BQT5m1J3iJIHkSb4qycq2wzllWsmmolaaFVnb+LPV9cIJ/nTud40ZsiiT0H3P+/wXIdbjx2fzF61OaeOQ=="
     },
+    "react-ga": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.5.6.tgz",
+      "integrity": "sha512-g04dz6zrbdHRxVaURPWT3RUbjLflh74sS6dCuhGeZupj7ii+UEt9lwTjALb2ST2w+7wAmzG1YqYlNX4yvRXe1g=="
+    },
     "react-mapbox-gl": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/react-mapbox-gl/-/react-mapbox-gl-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "REACT_APP_WIR_ENV=staging gh-pages -d build",
     "deploy:prod": "bash bin/deploy.sh"
   },
   "repository": {
@@ -34,6 +34,7 @@
     "node-sass": "^4.11.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
+    "react-ga": "^2.5.6",
     "react-mapbox-gl": "^4.0.2",
     "react-scripts": "^2.1.1"
   },

--- a/src/LegendModal.js
+++ b/src/LegendModal.js
@@ -4,7 +4,7 @@ import formatcoords from 'formatcoords';
 import TextWithParagraphs from './common/TextWithParagraphs';
 
 import { LegendShape } from './constants';
-import { getGoogleMapsUrl } from './utils';
+import { getGoogleMapsUrl, track } from './utils';
 
 const LegendModal = ({ legend: { emoji, emojiCode, coordinates, title, text }, onClose }) => (
   <div className="legend__modal">
@@ -17,6 +17,7 @@ const LegendModal = ({ legend: { emoji, emojiCode, coordinates, title, text }, o
             href={getGoogleMapsUrl(coordinates)}
             rel="noopener noreferrer"
             target="_blank"
+            onClick={track.bind(null, { action: 'google-map-opened', label: `${emoji} ${title}` })}
           >
             {formatcoords(coordinates, true).format('DD MM X', {
               latLonSeparator: ', ',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 
-export const ACCESS_TOKEN =
+export const MAPBOX_ACCESS_TOKEN =
   'pk.eyJ1IjoidWxhZGJvaGRhbiIsImEiOiJjam9kMDQ1NzYxOTYyM3FvanhpOXE1cDIzIn0.JiXb8lR9e53GqZz51PZdaQ';
+
+export const GA_ID = {
+  staging: 'UA-117143376-4',
+  production: 'UA-117143376-3',
+};
 
 const STYLE_PREFIX = 'mapbox://styles/uladbohdan';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,6 +21,8 @@ export const BELARUS_BOUNDS = [
   56.139922, // north
 ];
 
+export const EMOJI_SCALE_RATE = 4.5;
+
 export const LegendShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import ReactMapboxGl, { Marker } from 'react-mapbox-gl';
+import ReactMapboxGl, { Marker, ZoomControl } from 'react-mapbox-gl';
 import ReactGA from 'react-ga';
 import keyBy from 'lodash/keyBy';
-import throttle from 'lodash/throttle';
 
 import Clickable from './common/Clickable';
 import LegendModal from './LegendModal';
@@ -85,6 +84,7 @@ class App extends Component {
           center={MINSK}
           onZoom={this.handleZoom}
         >
+          <ZoomControl position="bottom-right" />
           {legends
             .filter(({ emoji }) => emoji)
             .map(({ id, title, coordinates, emoji, emojiCode }) => (

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,14 +8,7 @@ body {
 
 .legends {
   &__marker {
-    width: 1.75rem;
-    height: 1.75rem;
     cursor: pointer;
-  }
-
-  &__emoji {
-    width: 100%;
-    height: auto;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,2 +1,14 @@
+import ReactGA from 'react-ga';
+
 export const getGoogleMapsUrl = ([lng, lat], zoom = 7) =>
   `http://www.google.com/maps/place/${lat},${lng}/@${lat},${lng},${zoom}z`;
+
+export const track = options => {
+  if (!process.env.REACT_APP_WIR_ENV) {
+    return;
+  }
+  ReactGA.event({
+    category: 'Legends Map',
+    ...options,
+  });
+};


### PR DESCRIPTION
- add `track` on emoji & google maps link clicks
- change emoji `img` size depend on current map `zoom`
- add `zoom` control:

<img width="1239" alt="screen shot 2018-12-18 at 05 00 48" src="https://user-images.githubusercontent.com/11758660/50127404-fb337100-0281-11e9-88d0-aaad3385f8a3.png">
